### PR TITLE
test the translation, detection, and audio generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,8 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.11.457</version>
+      <!-- version>1.11.457</version -->
+      <version>1.11.816</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -116,7 +117,8 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-translate</artifactId>
-      <version>1.11.268</version>
+      <!--version>1.11.268</version-->
+      <version>1.11.816</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/example/AudioHandler.java
+++ b/src/main/java/example/AudioHandler.java
@@ -42,7 +42,8 @@ public class AudioHandler implements RequestHandler<S3Event, String>{
 
         String srcBucket = record.getS3().getBucket().getName();
         String srcKey = record.getS3().getObject().getUrlDecodedKey();
-        String dstBucket = srcBucket + "-trans";
+//        String dstBucket = srcBucket + "-trans";
+        String dstBucket = Configuration.audio_resultBucket;
         String dstKey = srcKey + ".mp3";
         // create client for each aws S3, Polly, and Comprehend
         AmazonS3 s3Client = AmazonS3ClientBuilder.defaultClient();

--- a/src/main/java/example/Handler.java
+++ b/src/main/java/example/Handler.java
@@ -70,7 +70,8 @@ public class Handler implements RequestHandler<S3Event, String> {
       String srcBucket = record.getS3().getBucket().getName();
       String srcKey = record.getS3().getObject().getUrlDecodedKey();
 
-      String dstBucket = srcBucket + "-trans";
+      //String dstBucket = srcBucket + "-trans";
+      String dstBucket = Configuration.text_resultBucket;
       String dstKey = srcKey + ".txt";
 
       // Infer the image type.
@@ -115,7 +116,8 @@ public class Handler implements RequestHandler<S3Event, String> {
 
         //*********************Test  translation logic
 
-        String REGION = "region";
+        //String REGION = "region";
+        String REGION = "us-east-2";
         AWSCredentialsProvider awsCreds = DefaultAWSCredentialsProviderChain.getInstance();
 
         AmazonTranslate translate = AmazonTranslateClient.builder()

--- a/src/main/java/example/transiteRek.html
+++ b/src/main/java/example/transiteRek.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <!-- **DO THIS**: -->
+    <!--   Replace SDK_VERSION_NUMBER with the current SDK version number -->
+    <script src="https://sdk.amazonaws.com/js/aws-sdk-2.696.0.min.js"></script>
+    <script src="./transiteRek.js" charset=“utf-8”></script>
+</head>
+<body>
+    <h1>HAPPY TRANSLATE/帮您翻译</h1>
+    <h2>Upload your image, we will help to translate the English to Chinese</h2>
+    <h2>上传文件，我们帮您将图片中的英文翻译成中文</h2>
+    <div id="app"></div>
+    <div id="text" charset=“utf-8”></div>
+    <script>
+        function getHtml(template) {
+            return template.join('\n');
+        }
+        uploadImage();
+    </script>
+    <p class="notes  hidden-xs">This site is still under construction. Please contact meiwenl@andrew.cmu.edu if you would like to make a contribution</p>
+</body>
+</html>

--- a/src/main/java/example/transiteRek.js
+++ b/src/main/java/example/transiteRek.js
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+//snippet-sourcedescription:[s3_photoExample.js demonstrates how to manipulate photos in albums stored in an Amazon S3 bucket.]
+//snippet-service:[s3]
+//snippet-keyword:[JavaScript]
+//snippet-sourcesyntax:[javascript]
+//snippet-keyword:[Code Sample]
+//snippet-keyword:[Amazon S3]
+//snippet-sourcetype:[full-example]
+//snippet-sourcedate:[]
+//snippet-sourceauthor:[AWS-JSDG]
+
+// ABOUT THIS NODE.JS SAMPLE: This sample is part of the SDK for JavaScript Developer Guide topic at
+// https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/s3-example-photo-album.html
+
+// snippet-start:[s3.JavaScript.photoAlbumExample.complete]
+// snippet-start:[s3.JavaScript.photoAlbumExample.config]
+// var albumBucketName = "mwlibucket2";
+// var dstBucketName = "mwlibucket2-trans"
+// var bucketRegion = "us-west-2";
+// var IdentityPoolId = "us-west-2:15bc05f2-4595-4c85-9509-226f69f8d539"; //transitepool
+var albumBucketName = "hapuerekbucket";
+var dstBucketName = "textresultbucket";
+var bucketRegion = "us-east-2";
+var IdentityPoolId = "us-east-2:1e70dbec-31db-4ee8-b023-ad74d4c8567a";
+AWS.config.update({
+    region: bucketRegion,
+    credentials: new AWS.CognitoIdentityCredentials({
+        IdentityPoolId: IdentityPoolId
+    })
+});
+
+var s3 = new AWS.S3({
+    apiVersion: "2006-03-01",
+    params: { Bucket: albumBucketName }
+});
+// snippet-end:[s3.JavaScript.photoAlbumExample.config]
+
+
+function uploadImage() {
+
+    var htmlTemplate = [
+        "<h3>",
+        "Upload the image you want to translate",
+        "</h3>",
+        '<input id="photoupload" type="file" accept="image/*">',
+        '<button id="addphoto" onclick="addPhoto()">',
+        "Add Photo",
+        "</button>",
+    ];
+
+    document.getElementById("app").innerHTML = getHtml(htmlTemplate);
+    document.getElementById("text").innerHTML = "";
+}
+
+function addPhoto() {
+    var files = document.getElementById("photoupload").files;
+    if (!files.length) {
+        return alert("Please choose a file to upload first.");
+    }
+    var file = files[0];
+    var fileName = file.name;
+
+    var photoKey = fileName;
+
+    // Use S3 ManagedUpload class as it supports multipart uploads
+    var upload = new AWS.S3.ManagedUpload({
+        params: {
+            Bucket: albumBucketName,
+            Key: photoKey,
+            Body: file,
+            ACL: "public-read"
+        }
+    });
+
+    var promise = upload.promise();
+
+    promise.then(
+        function(data) {
+            alert("Successfully uploaded photo.");
+            viewphoto(photoKey); //change to viewphoto and showTransition button
+        },
+        function(err) {
+            return alert("There was an error uploading your photo: ", err.message);
+        }
+    );
+}
+
+// snippet-start:[s3.JavaScript.photoAlbumExample.viewAlbum]
+function viewphoto(photoKey) {
+
+    var params = {
+        Bucket: albumBucketName,
+        Key: photoKey,
+    };
+
+    s3.getObject(params, function(err,data) {
+        if (err) {
+            return alert("Cannot find you uploaded image: " + err.message);
+        }
+        var href = this.request.httpRequest.endpoint.href;
+        var bucketUrl = href + albumBucketName + "/";
+        var photoUrl = bucketUrl + encodeURIComponent(photoKey);
+        var htmlTemplate = [
+            "<h2>",
+            "Your Uploaded Image",
+            "</h2>",
+            "<div>",
+            '<img style="width:128px;height:128px;" src="' + photoUrl + '"/>',
+            "</div>",
+            "<h2>",
+            "\n ",
+            "</h2>",
+            '<button id="translate" onclick="trans(\'' + photoKey + "')\">",
+            "Parse Object in the Image",
+            "</button>"
+        ];
+        document.getElementById("app").innerHTML = getHtml(htmlTemplate);
+    });
+}
+// snippet-start:[s3.JavaScript.photoAlbumExample.translate]
+function trans(photoKey) {
+
+    var dstKey = photoKey + ".txt";
+    //var dstKey = "outputfile.txt";
+    var params = {
+        Bucket: dstBucketName,
+        Key: dstKey,
+    };
+
+    s3.getObject(params, function(err,data) {
+        if (err) {
+            return alert("Cannot find you uploaded image: " + err.message);
+        }
+
+        var href = this.request.httpRequest.endpoint.href;
+        var bucketUrl = href + dstBucketName + "/";
+        var txtUrl = bucketUrl + encodeURIComponent(dstKey);
+        var htmlTemplate = [
+            "<h2>",
+            "In Chinese, the object in above image means:  ",
+            "</h2>",
+            "<div>",
+            data.Body.toString('utf-8'),
+            "</div>",
+            "<h2>",
+            "\n ",
+            "</h2>",
+            '<button id="home" onclick="uploadImage()">',
+            "\n Another Translation",
+            "</button>"
+        ];
+        document.getElementById("text").innerHTML = getHtml(htmlTemplate);
+    });
+}


### PR DESCRIPTION
# pom.xml
- The change of library version in ...sdk-s3 and ...sdk-translate are actually required by the rekognition, not by polly nor comprehend. This change should be in my last merge request but was forgot to add there.
- Polly and Comprehend libraries can stay at version 1.11.268, do not need to be the same as s3, rekognition, or translate libs.

# Handler class
- Update the dst bucket name following string defined in Configuration file
- Tested in html web page, no serious problem found. Some translation errors were noticed (due to the translation service provided by AWS)

# AudioHandler class
- Update the dst bucket name following string defined in Configuration file
- Tested in S3 bucket. mp3 file successfully generated in s3. Downloaded the mp3 file and can play well.

# transiteRek.* files
- These files were adapted from the transite.* files, accordingly. They were used to test the object recognition and translation feature.
- I tried to add "play audio" button in these files to test the audio function. But gave up half way...